### PR TITLE
Support for PHP 8.4 (#933)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-20.04]
-                php: [8.3, 8.2, 8.1, 8.0]
+                php: [8.4, 8.3, 8.2, 8.1, 8.0]
                 ffmpeg: [5.0, 4.4]
                 dependency-version: [prefer-lowest, prefer-stable]
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3",
+        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
         "evenement/evenement": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "spatie/temporary-directory": "^2.0",
@@ -57,7 +57,7 @@
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.10",
+        "phpunit/phpunit": "^9.5.10 || ^10.0",
         "mockery/mockery": "^1.5"
     },
     "autoload": {

--- a/tests/Alchemy/BinaryDriver/AbstractProcessBuilderFactoryTrait.php
+++ b/tests/Alchemy/BinaryDriver/AbstractProcessBuilderFactoryTrait.php
@@ -7,7 +7,7 @@ use Alchemy\BinaryDriver\ProcessBuilderFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\ExecutableFinder;
 
-abstract class AbstractProcessBuilderFactoryTest extends TestCase
+trait AbstractProcessBuilderFactoryTrait
 {
     public static $phpBinary;
 

--- a/tests/Alchemy/BinaryDriver/LTSProcessBuilderFactoryTest.php
+++ b/tests/Alchemy/BinaryDriver/LTSProcessBuilderFactoryTest.php
@@ -3,9 +3,13 @@
 namespace Alchemy\Tests\BinaryDriver;
 
 use Alchemy\BinaryDriver\ProcessBuilderFactory;
+use Alchemy\Tests\BinaryDriver\AbstractProcessBuilderFactoryTrait;
+use Tests\FFMpeg\Unit\TestCase;
 
-class LTSProcessBuilderFactoryTest extends AbstractProcessBuilderFactoryTest
+class LTSProcessBuilderFactoryTest extends TestCase
 {
+    use AbstractProcessBuilderFactoryTrait;
+
     public function setUp(): void
     {
         if (!class_exists('Symfony\Component\Process\ProcessBuilder')) {

--- a/tests/Alchemy/BinaryDriver/NONLTSProcessBuilderFactoryTest.php
+++ b/tests/Alchemy/BinaryDriver/NONLTSProcessBuilderFactoryTest.php
@@ -3,9 +3,13 @@
 namespace Alchemy\Tests\BinaryDriver;
 
 use Alchemy\BinaryDriver\ProcessBuilderFactory;
+use Alchemy\Tests\BinaryDriver\AbstractProcessBuilderFactoryTrait;
+use Tests\FFMpeg\Unit\TestCase;
 
-class NONLTSProcessBuilderFactoryTest extends AbstractProcessBuilderFactoryTest
+class NONLTSProcessBuilderFactoryTest extends TestCase
 {
+    use AbstractProcessBuilderFactoryTrait;
+
     protected function getProcessBuilderFactory($binary)
     {
         ProcessBuilderFactory::$emulateSfLTS = true;


### PR DESCRIPTION
* Add PHP 8.4 to test matrix
* Refactored `AbstractProcessBuilderFactoryTest` to trait

| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Explain the contents of the PR.

#### Why?

Which problem does the PR fix?

#### Example Usage

```php
$foo = new Foo();

// Now we can do
$foo->doSomething();

// Remove this section if not needed
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here (Remove this section if not needed).

#### To Do

- [ ] Create tests
